### PR TITLE
fix(webpack-config): add includePaths and data for app sass files

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -118,6 +118,7 @@ module.exports = function(webpackEnv) {
       loaders.push({
         loader: require.resolve(preProcessor),
         options: {
+          ...cssOptions,
           sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
         },
       });
@@ -573,6 +574,8 @@ module.exports = function(webpackEnv) {
                     : isEnvDevelopment,
                   modules: true,
                   getLocalIdent: getCSSModuleLocalIdent,
+                  data: "@import 'themes/westfield';",
+                  includePaths: [path.join(paths.appNodeModules, 'ui')],
                 },
                 'sass-loader'
               )


### PR DESCRIPTION
When the tools files like `dirg` were included into the sass module files in the local repo the sass loader couldn't follow the path. 

We can add the path to include and the theme with a relatively small change, just need to give the `cssOptions` passed into `getStyleLoaders` function back to the loader when `preProcessor` is true.